### PR TITLE
feat: allow direct Hessian retrieval

### DIFF
--- a/torch_influence/__init__.py
+++ b/torch_influence/__init__.py
@@ -10,7 +10,8 @@ __all__ = [
     "AutogradInfluenceModule",
     "CGInfluenceModule",
     "LiSSAInfluenceModule",
+    "HVPModule"
 ]
 
 from torch_influence.base import BaseInfluenceModule, BaseObjective
-from torch_influence.modules import AutogradInfluenceModule, CGInfluenceModule, LiSSAInfluenceModule
+from torch_influence.modules import AutogradInfluenceModule, CGInfluenceModule, LiSSAInfluenceModule, HVPModule


### PR DESCRIPTION
Hey,

Greate codebase- well-written and nicely documented! I spent the last few days looking for good and efficient ways to compute the Hessian of a model in Pytorch but almost all answers are either outdated, do not work, or are too slow (straightforward double-loops). However with a few simple modifications, it can be easily computed using this codebase:

```python
module = AutogradInfluenceModule(
  model=model,
  objective=MyObjective(),  
  train_loader=loader,
  test_loader=None,
  device=device,
  damp=0,
  store_as_hessian=True
)
H = module.get_hessian()
```

I figured it would be nice to have it as part of the repo itself! I can also add a short barebones example in the `examples` folder if that would be of value?