### PR TITLE
feat: Add docstrings; Add Support for UserDict in _transfer_to_device

### DIFF
--- a/torch_influence/base.py
+++ b/torch_influence/base.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Any, List, Optional, Union, Iterator, Tuple
+from collections import UserDict
 
 import numpy as np
 import torch
@@ -319,12 +320,12 @@ class BaseInfluenceModule(abc.ABC):
 
     # Data helpers
 
-    def _transfer_to_device(self, batch: Union[torch.Tensor, list, tuple, dict]):
+    def _transfer_to_device(self, batch):
         if isinstance(batch, torch.Tensor):
             return batch.to(self.device)
         elif isinstance(batch, (tuple, list)):
             return type(batch)(self._transfer_to_device(x) for x in batch)
-        elif isinstance(batch, dict):
+        elif isinstance(batch, (dict, UserDict)):
             return {k: self._transfer_to_device(x) for k, x in batch.items()}
         else:
             raise NotImplementedError()


### PR DESCRIPTION
This PR
- **Docstrings:** Adds docstring to undocumented methods in base.py
- **`torch-influence` & `transformers`:** Updates the `_transfer_to_device` method to support `UserDict` instances. The Hugging Face `BatchEncoding` class, which is a common otype for a batch in the library, inherits from `UserDict` but not from `dict`. This change ensures that `_transfer_to_device` correctly handles these batch types, fixing error-raising in `_transfer_to_device` that prevented `torch-influence` from working seamlessly with the transformers library.
